### PR TITLE
Add some built-in filesystems, fix some wrong signatures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "php": "^7.4|^8.0",
     "ext-ffi": "*",
     "sj-i/phpdoc-type-reader": "0.1.0",
-    "sj-i/typed-cdata": "0.0.4"
+    "sj-i/typed-cdata": "0.0.4",
+    "psr/log": "^1.1"
   },
   "require-dev": {
     "phpunit/phpunit": "9.5",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
   "require": {
     "php": "^7.4|^8.0",
     "ext-ffi": "*",
-    "sj-i/phpdoc-type-reader": "0.0.3",
-    "sj-i/typed-cdata": "0.0.1"
+    "sj-i/phpdoc-type-reader": "0.1.0",
+    "sj-i/typed-cdata": "0.0.4"
   },
   "require-dev": {
     "phpunit/phpunit": "9.5",

--- a/example/DummyFs.php
+++ b/example/DummyFs.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-fuse package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use Fuse\FilesystemDefaultImplementationTrait;
+use Fuse\FilesystemInterface;
+use Fuse\Libc\Errno\Errno;
+use Fuse\Libc\Fuse\FuseFileInfo;
+use Fuse\Libc\Fuse\FuseFillDir;
+use Fuse\Libc\Fuse\FuseReadDirBuffer;
+use Fuse\Libc\String\CBytesBuffer;
+use Fuse\Libc\Sys\Stat\Stat;
+
+class DummyFs implements FilesystemInterface
+{
+    use FilesystemDefaultImplementationTrait;
+
+    const FILE_PATH = '/example';
+    const FILE_NAME = 'example';
+    const FILE_CONTENT = 'hello FUSE from PHP' . PHP_EOL;
+
+    public function getattr(string $path, Stat $stat): int
+    {
+        echo "attr read {$path}" . PHP_EOL;
+
+        if ($path === '/') {
+            $stat->st_mode = Stat::S_IFDIR | 0755;
+            $stat->st_nlink = 2;
+            $stat->st_uid = getmyuid();
+            $stat->st_gid = getmygid();
+            return 0;
+        }
+
+        if ($path === self::FILE_PATH) {
+            $stat->st_mode = Stat::S_IFREG | 0777;
+            $stat->st_nlink = 1;
+            $stat->st_size = strlen(self::FILE_CONTENT);
+            $stat->st_uid = getmyuid();
+            $stat->st_gid = getmygid();
+            return 0;
+        }
+
+        return -Errno::ENOENT;
+    }
+
+    public function readdir(
+        string $path,
+        FuseReadDirBuffer $buf,
+        FuseFillDir $filler,
+        int $offset,
+        FuseFileInfo $fuse_file_info
+    ): int {
+        $filler($buf, '.', null, 0);
+        $filler($buf, '..', null, 0);
+        $filler($buf, self::FILE_NAME, null, 0);
+
+        return 0;
+    }
+
+    public function open(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        echo "open {$path}" . PHP_EOL;
+
+        if ($path !== self::FILE_PATH) {
+            return -Errno::ENOENT;
+        }
+
+        return 0;
+    }
+
+    public function read(string $path, CBytesBuffer $buffer, int $size, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        echo "read {$path}" . PHP_EOL;
+
+        $len = strlen(self::FILE_CONTENT);
+
+        if ($offset + $size > $len) {
+            $size = ($len - $offset);
+        }
+
+        $content = substr(self::FILE_CONTENT, $offset, $size);
+        $buffer->write($content, $size);
+
+        return $size;
+    }
+}

--- a/example/dummy_file_oo.php
+++ b/example/dummy_file_oo.php
@@ -1,90 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 include __DIR__ . "/../vendor/autoload.php";
+include __DIR__ . "/DummyFs.php";
 
-use Fuse\FilesystemDefaultImplementationTrait;
-use Fuse\FilesystemInterface;
-use Fuse\Libc\Errno\Errno;
-use Fuse\Libc\Fuse\FuseFileInfo;
-use Fuse\Libc\Fuse\FuseFillDir;
-use Fuse\Libc\Fuse\FuseReadDirBuffer;
-use Fuse\Libc\String\CBytesBuffer;
-use Fuse\Libc\Sys\Stat\Stat;
 use Fuse\Mounter;
-
-class DummyFs implements FilesystemInterface
-{
-    use FilesystemDefaultImplementationTrait;
-
-    const FILE_PATH = '/example';
-    const FILE_NAME = 'example';
-    const FILE_CONTENT = 'hello FUSE from PHP' . PHP_EOL;
-
-    public function getattr(string $path, Stat $stat): int
-    {
-        echo "attr read {$path}" . PHP_EOL;
-
-        if ($path === '/') {
-            $stat->st_mode = Stat::S_IFDIR | 0755;
-            $stat->st_nlink = 2;
-            $stat->st_uid = getmyuid();
-            $stat->st_gid = getmygid();
-            return 0;
-        }
-
-        if ($path === self::FILE_PATH) {
-            $stat->st_mode = Stat::S_IFREG | 0777;
-            $stat->st_nlink = 1;
-            $stat->st_size = strlen(self::FILE_CONTENT);
-            $stat->st_uid = getmyuid();
-            $stat->st_gid = getmygid();
-            return 0;
-        }
-
-        return -Errno::ENOENT;
-    }
-
-    public function readdir(
-        string $path,
-        FuseReadDirBuffer $buf,
-        FuseFillDir $filler,
-        int $offset,
-        FuseFileInfo $fuse_file_info
-    ): int {
-        $filler($buf, '.', null, 0);
-        $filler($buf, '..', null, 0);
-        $filler($buf, self::FILE_NAME, null, 0);
-
-        return 0;
-    }
-
-    public function open(string $path, FuseFileInfo $fuse_file_info): int
-    {
-        echo "open {$path}" . PHP_EOL;
-
-        if ($path !== self::FILE_PATH) {
-            return -Errno::ENOENT;
-        }
-
-        return 0;
-    }
-
-    public function read(string $path, CBytesBuffer $buffer, int $size, int $offset, FuseFileInfo $fuse_file_info): int
-    {
-        echo "read {$path}" . PHP_EOL;
-
-        $len = strlen(self::FILE_CONTENT);
-
-        if ($offset + $size > $len) {
-            $size = ($len - $offset);
-        }
-
-        $content = substr(self::FILE_CONTENT, $offset, $size);
-        $buffer->write($content, $size);
-
-        return $size;
-    }
-}
 
 $mounter = new Mounter();
 return $mounter->mount('/tmp/example/', new DummyFs());

--- a/example/log_unimplemented.php
+++ b/example/log_unimplemented.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-fuse package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . "/../vendor/autoload.php";
+include __DIR__ . "/DummyFs.php";
+
+use Fuse\Filesystem\Log\LogUnimplementedFilesystem;
+use Fuse\Mounter;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
+
+$mounter = new Mounter();
+
+return $mounter->mount(
+    '/tmp/example/',
+    new LogUnimplementedFilesystem(
+        new DummyFs(),
+        new class() implements LoggerInterface {
+            use LoggerTrait;
+
+            public function log($level, $message, array $context = [])
+            {
+                echo \json_encode(['message' => $message] + $context), PHP_EOL;
+            }
+        }
+    )
+);

--- a/src/Filesystem/BeforeAll/BeforeAllFilesystem.php
+++ b/src/Filesystem/BeforeAll/BeforeAllFilesystem.php
@@ -77,6 +77,7 @@ final class BeforeAllFilesystem implements FilesystemInterface
     public function getdir(string $path, FuseDirHandle $dirhandle, FuseDirFill $dirfill): int
     {
         ($this->callback)(__FUNCTION__, func_get_args());
+        /** @psalm-suppress DeprecatedMethod */
         return $this->getFilesystem()->getdir($path, $dirhandle, $dirfill);
     }
 

--- a/src/Filesystem/BeforeAll/BeforeAllFilesystem.php
+++ b/src/Filesystem/BeforeAll/BeforeAllFilesystem.php
@@ -1,0 +1,354 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-fuse package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fuse\Filesystem\BeforeAll;
+
+use Fuse\FilesystemFlagsImplementationTrait;
+use Fuse\FilesystemInterface;
+use Fuse\Libc\Fcntl\Flock;
+use Fuse\Libc\Fuse\FuseBufVec;
+use Fuse\Libc\Fuse\FuseConnInfo;
+use Fuse\Libc\Fuse\FuseDirFill;
+use Fuse\Libc\Fuse\FuseDirHandle;
+use Fuse\Libc\Fuse\FuseFileInfo;
+use Fuse\Libc\Fuse\FuseFillDir;
+use Fuse\Libc\Fuse\FuseIoctlArgPointer;
+use Fuse\Libc\Fuse\FuseIoctlDataPointer;
+use Fuse\Libc\Fuse\FusePollHandle;
+use Fuse\Libc\Fuse\FusePrivateData;
+use Fuse\Libc\Fuse\FuseReadDirBuffer;
+use Fuse\Libc\String\CBytesBuffer;
+use Fuse\Libc\String\CStringBuffer;
+use Fuse\Libc\Sys\Stat\Stat;
+use Fuse\Libc\Sys\StatVfs\StatVfs;
+use Fuse\Libc\Time\TimeSpec;
+use Fuse\Libc\Utime\UtimBuf;
+use Fuse\MountableFilesystemTrait;
+use TypedCData\TypedCDataArray;
+
+final class BeforeAllFilesystem implements FilesystemInterface
+{
+    use MountableFilesystemTrait;
+    use FilesystemFlagsImplementationTrait;
+
+    /** @var callable */
+    private $callback;
+    private FilesystemInterface $filesystem;
+
+    /**
+     * @param callable(string,array):void $callback
+     */
+    public function __construct(
+        callable $callback,
+        FilesystemInterface $filesystem
+    ) {
+        $this->callback = $callback;
+        $this->filesystem = $filesystem;
+    }
+
+    private function getFilesystem(): FilesystemInterface
+    {
+        return $this->filesystem;
+    }
+
+    public function getattr(string $path, Stat $stat): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->getattr($path, $stat);
+    }
+
+    public function readlink(string $path, CStringBuffer $buffer, int $size): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->readlink($path, $buffer, $size);
+    }
+
+    /** @deprecated */
+    public function getdir(string $path, FuseDirHandle $dirhandle, FuseDirFill $dirfill): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->getdir($path, $dirhandle, $dirfill);
+    }
+
+    public function mknod(string $path, int $mode, int $dev): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->mknod($path, $mode, $dev);
+    }
+
+    public function mkdir(string $path, int $mode): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->mkdir($path, $mode);
+    }
+
+    public function unlink(string $path): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->unlink($path);
+    }
+
+    public function rmdir(string $path): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->rmdir($path);
+    }
+
+    public function symlink(string $path, string $link): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->symlink($path, $link);
+    }
+
+    public function rename(string $from, string $to): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->rename($from, $to);
+    }
+
+    public function link(string $path, string $link): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->link($path, $link);
+    }
+
+    public function chmod(string $path, int $mode): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->chmod($path, $mode);
+    }
+
+    public function chown(string $path, int $uid, int $gid): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->chown($path, $uid, $gid);
+    }
+
+    public function truncate(string $path, int $offset): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->truncate($path, $offset);
+    }
+
+    public function utime(string $path, UtimBuf $utime_buf): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->utime($path, $utime_buf);
+    }
+
+    public function open(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->open($path, $fuse_file_info);
+    }
+
+    public function read(string $path, CBytesBuffer $buffer, int $size, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->read($path, $buffer, $size, $offset, $fuse_file_info);
+    }
+
+    public function write(string $path, string $buffer, int $size, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->write($path, $buffer, $size, $offset, $fuse_file_info);
+    }
+
+    public function statfs(string $path, StatVfs $statvfs): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->statfs($path, $statvfs);
+    }
+
+    public function flush(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->flush($path, $fuse_file_info);
+    }
+
+    public function release(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->release($path, $fuse_file_info);
+    }
+
+    public function fsync(string $path, int $flags, FuseFileInfo $fuse_file_info): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->fsync($path, $flags, $fuse_file_info);
+    }
+
+    public function setxattr(string $path, string $name, string $value, int $size): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->setxattr($path, $name, $value, $size);
+    }
+
+    public function getxattr(string $path, string $name, ?string &$value, int $size): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->getxattr($path, $name, $value, $size);
+    }
+
+    public function listxattr(string $path, ?string &$value, int $size): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->listxattr($path, $value, $size);
+    }
+
+    public function removexattr(string $size, string $name): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->removexattr($size, $name);
+    }
+
+    public function opendir(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->opendir($path, $fuse_file_info);
+    }
+
+    public function readdir(
+        string $path,
+        FuseReadDirBuffer $buf,
+        FuseFillDir $filler,
+        int $offset,
+        FuseFileInfo $fuse_file_info
+    ): int {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->readdir($path, $buf, $filler, $offset, $fuse_file_info);
+    }
+
+    public function releasedir(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->releasedir($path, $fuse_file_info);
+    }
+
+    public function fsyncdir(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->fsyncdir($path, $fuse_file_info);
+    }
+
+    public function init(FuseConnInfo $conn): ?FusePrivateData
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->init($conn);
+    }
+
+    public function destroy(?FusePrivateData $private_data): void
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        $this->getFilesystem()->destroy($private_data);
+    }
+
+    public function access(string $path, int $mode): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->access($path, $mode);
+    }
+
+    public function create(string $path, int $mode, FuseFileInfo $fuse_file_info): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->create($path, $mode, $fuse_file_info);
+    }
+
+    public function ftruncate(string $path, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->ftruncate($path, $offset, $fuse_file_info);
+    }
+
+    public function fgetattr(string $path, Stat $stat, FuseFileInfo $fuse_file_info): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->fgetattr($path, $stat, $fuse_file_info);
+    }
+
+    public function lock(string $path, FuseFileInfo $fuse_file_info, int $cmd, Flock $flock): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->lock($path, $fuse_file_info, $cmd, $flock);
+    }
+
+    /**
+     * @param TypedCDataArray<TimeSpec> $tv
+     */
+    public function utimens(string $path, TypedCDataArray $tv): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->utimens($path, $tv);
+    }
+
+    public function bmap(string $path, int $blocksize, int &$idx): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->bmap($path, $blocksize, $idx);
+    }
+
+    public function ioctl(
+        string $path,
+        int $cmd,
+        FuseIoctlArgPointer $arg,
+        FuseFileInfo $fuse_file_info,
+        int $flags,
+        FuseIoctlDataPointer $data
+    ): int {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->ioctl($path, $cmd, $arg, $fuse_file_info, $flags, $data);
+    }
+
+    public function poll(
+        string $path,
+        FuseFileInfo $fuse_file_info,
+        FusePollHandle $fuse_pollhandle,
+        int &$reventsp
+    ): int {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->poll($path, $fuse_file_info, $fuse_pollhandle, $reventsp);
+    }
+
+    public function writeBuf(string $path, FuseBufVec $buf, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->writeBuf($path, $buf, $offset, $fuse_file_info);
+    }
+
+    /**
+     * @param TypedCDataArray<FuseBufVec> $bufp
+     */
+    public function readBuf(
+        string $path,
+        TypedCDataArray $bufp,
+        int $size,
+        int $offset,
+        FuseFileInfo $fuse_file_info
+    ): int {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->readBuf($path, $bufp, $size, $offset, $fuse_file_info);
+    }
+
+    public function flock(string $path, FuseFileInfo $fuse_file_info, int $op): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->flock($path, $fuse_file_info, $op);
+    }
+
+    public function fallocate(string $path, int $mode, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        ($this->callback)(__FUNCTION__, func_get_args());
+        return $this->getFilesystem()->fallocate($path, $mode, $offset, $fuse_file_info);
+    }
+}

--- a/src/Filesystem/Delegation/DelegationFilesystemTrait.php
+++ b/src/Filesystem/Delegation/DelegationFilesystemTrait.php
@@ -303,7 +303,7 @@ trait DelegationFilesystemTrait
     /**
      * void (*destroy) (void *);
      */
-    public function destroy(FusePrivateData $private_data): void
+    public function destroy(?FusePrivateData $private_data): void
     {
         $this->delegate(__FUNCTION__, func_get_args());
     }

--- a/src/Filesystem/Delegation/DelegationFilesystemTrait.php
+++ b/src/Filesystem/Delegation/DelegationFilesystemTrait.php
@@ -43,13 +43,15 @@ trait DelegationFilesystemTrait
 
     private FilesystemInterface $filesystem;
 
-    private function setDelegation(FilesystemInterface $filesystem)
+    private function setDelegation(FilesystemInterface $filesystem): void
     {
         $this->filesystem = $filesystem;
     }
 
+    /** @return int|null|FusePrivateData|void */
     private function delegate(string $method_name, array $args)
     {
+        /** @var int|null|FusePrivateData|void */
         return $this->filesystem->$method_name(...$args);
     }
 
@@ -58,6 +60,7 @@ trait DelegationFilesystemTrait
      */
     public function getattr(string $path, Stat $stat): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -66,6 +69,7 @@ trait DelegationFilesystemTrait
      */
     public function readlink(string $path, CStringBuffer $buffer, int $size): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -76,6 +80,7 @@ trait DelegationFilesystemTrait
      */
     public function getdir(string $path, FuseDirHandle $dirhandle, FuseDirFill $dirfill): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -84,6 +89,7 @@ trait DelegationFilesystemTrait
      */
     public function mknod(string $path, int $mode, int $dev): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -92,6 +98,7 @@ trait DelegationFilesystemTrait
      */
     public function mkdir(string $path, int $mode): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -100,6 +107,7 @@ trait DelegationFilesystemTrait
      */
     public function unlink(string $path): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -108,6 +116,7 @@ trait DelegationFilesystemTrait
      */
     public function rmdir(string $path): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -116,6 +125,7 @@ trait DelegationFilesystemTrait
      */
     public function symlink(string $path, string $link): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -124,6 +134,7 @@ trait DelegationFilesystemTrait
      */
     public function rename(string $from, string $to): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -132,6 +143,7 @@ trait DelegationFilesystemTrait
      */
     public function link(string $path, string $link): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -140,6 +152,7 @@ trait DelegationFilesystemTrait
      */
     public function chmod(string $path, int $mode): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -148,6 +161,7 @@ trait DelegationFilesystemTrait
      */
     public function chown(string $path, int $uid, int $gid): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -156,6 +170,7 @@ trait DelegationFilesystemTrait
      */
     public function truncate(string $path, int $offset): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -164,6 +179,7 @@ trait DelegationFilesystemTrait
      */
     public function utime(string $path, UtimBuf $utime_buf): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -172,6 +188,7 @@ trait DelegationFilesystemTrait
      */
     public function open(string $path, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -180,6 +197,7 @@ trait DelegationFilesystemTrait
      */
     public function read(string $path, CBytesBuffer $buffer, int $size, int $offset, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -188,6 +206,7 @@ trait DelegationFilesystemTrait
      */
     public function write(string $path, string $buffer, int $size, int $offset, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -196,6 +215,7 @@ trait DelegationFilesystemTrait
      */
     public function statfs(string $path, StatVfs $statvfs): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -204,6 +224,7 @@ trait DelegationFilesystemTrait
      */
     public function flush(string $path, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -212,6 +233,7 @@ trait DelegationFilesystemTrait
      */
     public function release(string $path, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -220,6 +242,7 @@ trait DelegationFilesystemTrait
      */
     public function fsync(string $path, int $flags, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -228,6 +251,7 @@ trait DelegationFilesystemTrait
      */
     public function setxattr(string $path, string $name, string $value, int $size): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -236,6 +260,7 @@ trait DelegationFilesystemTrait
      */
     public function getxattr(string $path, string $name, ?string &$value, int $size): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -244,6 +269,7 @@ trait DelegationFilesystemTrait
      */
     public function listxattr(string $path, ?string &$value, int $size): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -252,6 +278,7 @@ trait DelegationFilesystemTrait
      */
     public function removexattr(string $size, string $name): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -260,6 +287,7 @@ trait DelegationFilesystemTrait
      */
     public function opendir(string $path, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -273,6 +301,7 @@ trait DelegationFilesystemTrait
         int $offset,
         FuseFileInfo $fuse_file_info
     ): int {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -281,6 +310,7 @@ trait DelegationFilesystemTrait
      */
     public function releasedir(string $path, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -289,6 +319,7 @@ trait DelegationFilesystemTrait
      */
     public function fsyncdir(string $path, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -297,6 +328,7 @@ trait DelegationFilesystemTrait
      */
     public function init(FuseConnInfo $conn): ?FusePrivateData
     {
+        /** @var ?FusePrivateData */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -313,6 +345,7 @@ trait DelegationFilesystemTrait
      */
     public function access(string $path, int $mode): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -321,6 +354,7 @@ trait DelegationFilesystemTrait
      */
     public function create(string $path, int $mode, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -329,6 +363,7 @@ trait DelegationFilesystemTrait
      */
     public function ftruncate(string $path, int $offset, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -337,6 +372,7 @@ trait DelegationFilesystemTrait
      */
     public function fgetattr(string $path, Stat $stat, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -345,6 +381,7 @@ trait DelegationFilesystemTrait
      */
     public function lock(string $path, FuseFileInfo $fuse_file_info, int $cmd, Flock $flock): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -355,6 +392,7 @@ trait DelegationFilesystemTrait
      */
     public function utimens(string $path, TypedCDataArray $tv): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -363,6 +401,7 @@ trait DelegationFilesystemTrait
      */
     public function bmap(string $path, int $blocksize, int &$idx): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -377,6 +416,7 @@ trait DelegationFilesystemTrait
         int $flags,
         FuseIoctlDataPointer $data
     ): int {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -389,6 +429,7 @@ trait DelegationFilesystemTrait
         FusePollHandle $fuse_pollhandle,
         int &$reventsp
     ): int {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -397,6 +438,7 @@ trait DelegationFilesystemTrait
      */
     public function writeBuf(string $path, FuseBufVec $buf, int $offset, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -412,6 +454,7 @@ trait DelegationFilesystemTrait
         int $offset,
         FuseFileInfo $fuse_file_info
     ): int {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -420,6 +463,7 @@ trait DelegationFilesystemTrait
      */
     public function flock(string $path, FuseFileInfo $fuse_file_info, int $op): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 
@@ -428,6 +472,7 @@ trait DelegationFilesystemTrait
      */
     public function fallocate(string $path, int $mode, int $offset, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->delegate(__FUNCTION__, func_get_args());
     }
 }

--- a/src/Filesystem/Delegation/DelegationFilesystemTrait.php
+++ b/src/Filesystem/Delegation/DelegationFilesystemTrait.php
@@ -1,0 +1,433 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-fuse package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fuse\Filesystem\Delegation;
+
+use Fuse\FilesystemFlagsImplementationTrait;
+use Fuse\FilesystemInterface;
+use Fuse\Libc\Fcntl\Flock;
+use Fuse\Libc\Fuse\FuseBufVec;
+use Fuse\Libc\Fuse\FuseConnInfo;
+use Fuse\Libc\Fuse\FuseDirFill;
+use Fuse\Libc\Fuse\FuseDirHandle;
+use Fuse\Libc\Fuse\FuseFileInfo;
+use Fuse\Libc\Fuse\FuseFillDir;
+use Fuse\Libc\Fuse\FuseIoctlArgPointer;
+use Fuse\Libc\Fuse\FuseIoctlDataPointer;
+use Fuse\Libc\Fuse\FusePollHandle;
+use Fuse\Libc\Fuse\FusePrivateData;
+use Fuse\Libc\Fuse\FuseReadDirBuffer;
+use Fuse\Libc\String\CBytesBuffer;
+use Fuse\Libc\String\CStringBuffer;
+use Fuse\Libc\Sys\Stat\Stat;
+use Fuse\Libc\Sys\StatVfs\StatVfs;
+use Fuse\Libc\Time\TimeSpec;
+use Fuse\Libc\Utime\UtimBuf;
+use Fuse\MountableFilesystemTrait;
+use TypedCData\TypedCDataArray;
+
+trait DelegationFilesystemTrait
+{
+    use MountableFilesystemTrait;
+    use FilesystemFlagsImplementationTrait;
+
+    private FilesystemInterface $filesystem;
+
+    private function setDelegation(FilesystemInterface $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    private function delegate(string $method_name, array $args)
+    {
+        return $this->filesystem->$method_name(...$args);
+    }
+
+    /**
+     * int (*getattr) (const char *, struct stat *);
+     */
+    public function getattr(string $path, Stat $stat): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*readlink) (const char *, char *, size_t);
+     */
+    public function readlink(string $path, CStringBuffer $buffer, int $size): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*getdir) (const char *, fuse_dirh_t, fuse_dirfil_t);
+     *
+     * @deprecated
+     */
+    public function getdir(string $path, FuseDirHandle $dirhandle, FuseDirFill $dirfill): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*mknod) (const char *, mode_t, dev_t);
+     */
+    public function mknod(string $path, int $mode, int $dev): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*mkdir) (const char *, mode_t);
+     */
+    public function mkdir(string $path, int $mode): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*unlink) (const char *);
+     */
+    public function unlink(string $path): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*rmdir) (const char *);
+     */
+    public function rmdir(string $path): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*symlink) (const char *, const char *);
+     */
+    public function symlink(string $path, string $link): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*rename) (const char *, const char *);
+     */
+    public function rename(string $from, string $to): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*link) (const char *, const char *);
+     */
+    public function link(string $path, string $link): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*chmod) (const char *, mode_t);
+     */
+    public function chmod(string $path, int $mode): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*chown) (const char *, uid_t, gid_t);
+     */
+    public function chown(string $path, int $uid, int $gid): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*truncate) (const char *, off_t);
+     */
+    public function truncate(string $path, int $offset): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*utime) (const char *, struct utimbuf *);
+     */
+    public function utime(string $path, UtimBuf $utime_buf): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*open) (const char *, struct fuse_file_info *);
+     */
+    public function open(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*read) (const char *, char *, size_t, off_t, struct fuse_file_info *);
+     */
+    public function read(string $path, CBytesBuffer $buffer, int $size, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*write) (const char *, const char *, size_t, off_t, struct fuse_file_info *);
+     */
+    public function write(string $path, string $buffer, int $size, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*statfs) (const char *, struct statvfs *);
+     */
+    public function statfs(string $path, StatVfs $statvfs): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*flush) (const char *, struct fuse_file_info *);
+     */
+    public function flush(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*release) (const char *, struct fuse_file_info *);
+     */
+    public function release(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*fsync) (const char *, int, struct fuse_file_info *);
+     */
+    public function fsync(string $path, int $flags, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*setxattr) (const char *, const char *, const char *, size_t, int);
+     */
+    public function setxattr(string $path, string $name, string $value, int $size): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*getxattr) (const char *, const char *, char *, size_t);
+     */
+    public function getxattr(string $path, string $name, ?string &$value, int $size): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*listxattr) (const char *, char *, size_t);*
+     */
+    public function listxattr(string $path, ?string &$value, int $size): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*removexattr) (const char *, const char *);
+     */
+    public function removexattr(string $size, string $name): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*opendir) (const char *, struct fuse_file_info *);
+     */
+    public function opendir(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*readdir) (const char *, void *, fuse_fill_dir_t, off_t, struct fuse_file_info *);
+     */
+    public function readdir(
+        string $path,
+        FuseReadDirBuffer $buf,
+        FuseFillDir $filler,
+        int $offset,
+        FuseFileInfo $fuse_file_info
+    ): int {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*releasedir) (const char *, struct fuse_file_info *);
+     */
+    public function releasedir(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*fsyncdir) (const char *, int, struct fuse_file_info *);
+     */
+    public function fsyncdir(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * void *(*init) (struct fuse_conn_info *conn);
+     */
+    public function init(FuseConnInfo $conn): ?FusePrivateData
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * void (*destroy) (void *);
+     */
+    public function destroy(FusePrivateData $private_data): void
+    {
+        $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*access) (const char *, int);
+     */
+    public function access(string $path, int $mode): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*create) (const char *, mode_t, struct fuse_file_info *);
+     */
+    public function create(string $path, int $mode, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*ftruncate) (const char *, off_t, struct fuse_file_info *);
+     */
+    public function ftruncate(string $path, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*fgetattr) (const char *, struct stat *, struct fuse_file_info *);
+     */
+    public function fgetattr(string $path, Stat $stat, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*lock) (const char *, struct fuse_file_info *, int cmd, struct flock *);
+     */
+    public function lock(string $path, FuseFileInfo $fuse_file_info, int $cmd, Flock $flock): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*utimens) (const char *, const struct timespec tv[2]);
+     *
+     * @param TypedCDataArray<TimeSpec> $tv
+     */
+    public function utimens(string $path, TypedCDataArray $tv): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*bmap) (const char *, size_t blocksize, uint64_t *idx);
+     */
+    public function bmap(string $path, int $blocksize, int &$idx): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*ioctl) (const char *, int cmd, void *arg, struct fuse_file_info *, unsigned int flags, void *data);
+     */
+    public function ioctl(
+        string $path,
+        int $cmd,
+        FuseIoctlArgPointer $arg,
+        FuseFileInfo $fuse_file_info,
+        int $flags,
+        FuseIoctlDataPointer $data
+    ): int {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*poll) (const char *, struct fuse_file_info *, struct fuse_pollhandle *ph, unsigned *reventsp);
+     */
+    public function poll(
+        string $path,
+        FuseFileInfo $fuse_file_info,
+        FusePollHandle $fuse_pollhandle,
+        int &$reventsp
+    ): int {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*write_buf) (const char *, struct fuse_bufvec *buf, off_t off, struct fuse_file_info *);
+     */
+    public function writeBuf(string $path, FuseBufVec $buf, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*read_buf) (const char *, struct fuse_bufvec **bufp, size_t size, off_t off, struct fuse_file_info *);
+     *
+     * @param TypedCDataArray<FuseBufVec> $bufp
+     */
+    public function readBuf(
+        string $path,
+        TypedCDataArray $bufp,
+        int $size,
+        int $offset,
+        FuseFileInfo $fuse_file_info
+    ): int {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*flock) (const char *, struct fuse_file_info *, int op);
+     */
+    public function flock(string $path, FuseFileInfo $fuse_file_info, int $op): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*fallocate) (const char *, int, off_t, off_t, struct fuse_file_info *);
+     */
+    public function fallocate(string $path, int $mode, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+}

--- a/src/Filesystem/Log/LogUnimplementedFilesystem.php
+++ b/src/Filesystem/Log/LogUnimplementedFilesystem.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-fuse package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fuse\Filesystem\Log;
+
+use Fuse\Filesystem\BeforeAll\BeforeAllFilesystem;
+use Fuse\Filesystem\Delegation\DelegationFilesystemTrait;
+use Fuse\Filesystem\Null\NullFilesystem;
+use Fuse\Filesystem\Overlay\OverlayFilesystem;
+use Fuse\FilesystemInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+final class LogUnimplementedFilesystem implements FilesystemInterface
+{
+    use DelegationFilesystemTrait;
+
+    private const DEFAULT_MESSAGE = 'An unimplemented FUSE API is called';
+
+    private LoggerInterface $logger;
+    private string $log_level;
+    private string $message;
+
+    /** @param value-of<LogLevel::*> $log_level */
+    public function __construct(
+        FilesystemInterface $filesystem,
+        LoggerInterface $logger,
+        string $log_level = LogLevel::DEBUG,
+        string $message = self::DEFAULT_MESSAGE
+    ) {
+        $this->initialize($filesystem);
+        $this->logger = $logger;
+        $this->log_level = $log_level;
+        $this->message = $message;
+    }
+
+    private function initialize(FilesystemInterface $filesystem): void
+    {
+        $this->setDelegation(
+            new OverlayFilesystem(
+                $filesystem,
+                new BeforeAllFilesystem(
+                    fn(string $method, array $args) => $this->log($method, $args),
+                    new NullFilesystem()
+                )
+            )
+        );
+    }
+
+    private function log(string $method, array $args): void
+    {
+        $this->logger->log(
+            $this->log_level,
+            $this->message,
+            [
+                'method' => $method,
+                'args' => $args
+            ]
+        );
+    }
+}

--- a/src/Filesystem/Log/LogUnimplementedFilesystem.php
+++ b/src/Filesystem/Log/LogUnimplementedFilesystem.php
@@ -27,11 +27,22 @@ final class LogUnimplementedFilesystem implements FilesystemInterface
 
     private const DEFAULT_MESSAGE = 'An unimplemented FUSE API is called';
 
+    private const LOG_LEVELS = [
+        LogLevel::EMERGENCY,
+        LogLevel::ALERT,
+        LogLevel::CRITICAL,
+        LogLevel::ERROR,
+        LogLevel::WARNING,
+        LogLevel::NOTICE,
+        LogLevel::INFO,
+        LogLevel::DEBUG,
+    ];
+
     private LoggerInterface $logger;
     private string $log_level;
     private string $message;
 
-    /** @param value-of<LogLevel::*> $log_level */
+    /** @param value-of<self::LOG_LEVELS> $log_level */
     public function __construct(
         FilesystemInterface $filesystem,
         LoggerInterface $logger,

--- a/src/Filesystem/Null/NullFilesystem.php
+++ b/src/Filesystem/Null/NullFilesystem.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-fuse package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fuse\Filesystem\Null;
+
+use Fuse\FilesystemDefaultImplementationTrait;
+use Fuse\FilesystemInterface;
+
+final class NullFilesystem implements FilesystemInterface
+{
+    use FilesystemDefaultImplementationTrait;
+}

--- a/src/Filesystem/Overlay/OverlayFilesystem.php
+++ b/src/Filesystem/Overlay/OverlayFilesystem.php
@@ -1,0 +1,441 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-fuse package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fuse\Filesystem\Overlay;
+
+use Fuse\Filesystem\ReflectionFilesystem;
+use Fuse\FilesystemFlagsImplementationTrait;
+use Fuse\FilesystemInterface;
+use Fuse\Libc\Fcntl\Flock;
+use Fuse\Libc\Fuse\FuseBufVec;
+use Fuse\Libc\Fuse\FuseConnInfo;
+use Fuse\Libc\Fuse\FuseDirFill;
+use Fuse\Libc\Fuse\FuseDirHandle;
+use Fuse\Libc\Fuse\FuseFileInfo;
+use Fuse\Libc\Fuse\FuseFillDir;
+use Fuse\Libc\Fuse\FuseIoctlArgPointer;
+use Fuse\Libc\Fuse\FuseIoctlDataPointer;
+use Fuse\Libc\Fuse\FusePollHandle;
+use Fuse\Libc\Fuse\FusePrivateData;
+use Fuse\Libc\Fuse\FuseReadDirBuffer;
+use Fuse\Libc\String\CBytesBuffer;
+use Fuse\Libc\String\CStringBuffer;
+use Fuse\Libc\Sys\Stat\Stat;
+use Fuse\Libc\Sys\StatVfs\StatVfs;
+use Fuse\Libc\Time\TimeSpec;
+use Fuse\Libc\Utime\UtimBuf;
+use Fuse\MountableFilesystemTrait;
+use TypedCData\TypedCDataArray;
+
+final class OverlayFilesystem implements FilesystemInterface
+{
+    use MountableFilesystemTrait;
+    use FilesystemFlagsImplementationTrait;
+
+    private FilesystemInterface $main;
+    private FilesystemInterface $fallback;
+
+    public function __construct(
+        FilesystemInterface $main,
+        FilesystemInterface $fallback
+    ) {
+        $this->main = $main;
+        $this->fallback = $fallback;
+    }
+
+    private function fallbackIfDefault(string $method_name, array $args)
+    {
+        if (ReflectionFilesystem::instance($this->main)->isDefault($method_name)) {
+            return $this->fallback->$method_name(...$args);
+        }
+        return $this->main->$method_name(...$args);
+    }
+
+    /**
+     * int (*getattr) (const char *, struct stat *);
+     */
+    public function getattr(string $path, Stat $stat): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*readlink) (const char *, char *, size_t);
+     */
+    public function readlink(string $path, CStringBuffer $buffer, int $size): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*getdir) (const char *, fuse_dirh_t, fuse_dirfil_t);
+     *
+     * @deprecated
+     */
+    public function getdir(string $path, FuseDirHandle $dirhandle, FuseDirFill $dirfill): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*mknod) (const char *, mode_t, dev_t);
+     */
+    public function mknod(string $path, int $mode, int $dev): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*mkdir) (const char *, mode_t);
+     */
+    public function mkdir(string $path, int $mode): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*unlink) (const char *);
+     */
+    public function unlink(string $path): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*rmdir) (const char *);
+     */
+    public function rmdir(string $path): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*symlink) (const char *, const char *);
+     */
+    public function symlink(string $path, string $link): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*rename) (const char *, const char *);
+     */
+    public function rename(string $from, string $to): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*link) (const char *, const char *);
+     */
+    public function link(string $path, string $link): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*chmod) (const char *, mode_t);
+     */
+    public function chmod(string $path, int $mode): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*chown) (const char *, uid_t, gid_t);
+     */
+    public function chown(string $path, int $uid, int $gid): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*truncate) (const char *, off_t);
+     */
+    public function truncate(string $path, int $offset): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*utime) (const char *, struct utimbuf *);
+     */
+    public function utime(string $path, UtimBuf $utime_buf): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*open) (const char *, struct fuse_file_info *);
+     */
+    public function open(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*read) (const char *, char *, size_t, off_t, struct fuse_file_info *);
+     */
+    public function read(string $path, CBytesBuffer $buffer, int $size, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*write) (const char *, const char *, size_t, off_t, struct fuse_file_info *);
+     */
+    public function write(string $path, string $buffer, int $size, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*statfs) (const char *, struct statvfs *);
+     */
+    public function statfs(string $path, StatVfs $statvfs): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*flush) (const char *, struct fuse_file_info *);
+     */
+    public function flush(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*release) (const char *, struct fuse_file_info *);
+     */
+    public function release(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*fsync) (const char *, int, struct fuse_file_info *);
+     */
+    public function fsync(string $path, int $flags, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*setxattr) (const char *, const char *, const char *, size_t, int);
+     */
+    public function setxattr(string $path, string $name, string $value, int $size): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*getxattr) (const char *, const char *, char *, size_t);
+     */
+    public function getxattr(string $path, string $name, ?string &$value, int $size): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*listxattr) (const char *, char *, size_t);*
+     */
+    public function listxattr(string $path, ?string &$value, int $size): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*removexattr) (const char *, const char *);
+     */
+    public function removexattr(string $size, string $name): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*opendir) (const char *, struct fuse_file_info *);
+     */
+    public function opendir(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*readdir) (const char *, void *, fuse_fill_dir_t, off_t, struct fuse_file_info *);
+     */
+    public function readdir(
+        string $path,
+        FuseReadDirBuffer $buf,
+        FuseFillDir $filler,
+        int $offset,
+        FuseFileInfo $fuse_file_info
+    ): int {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*releasedir) (const char *, struct fuse_file_info *);
+     */
+    public function releasedir(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*fsyncdir) (const char *, int, struct fuse_file_info *);
+     */
+    public function fsyncdir(string $path, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * void *(*init) (struct fuse_conn_info *conn);
+     */
+    public function init(FuseConnInfo $conn): ?FusePrivateData
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * void (*destroy) (void *);
+     */
+    public function destroy(FusePrivateData $private_data): void
+    {
+        $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*access) (const char *, int);
+     */
+    public function access(string $path, int $mode): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*create) (const char *, mode_t, struct fuse_file_info *);
+     */
+    public function create(string $path, int $mode, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*ftruncate) (const char *, off_t, struct fuse_file_info *);
+     */
+    public function ftruncate(string $path, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*fgetattr) (const char *, struct stat *, struct fuse_file_info *);
+     */
+    public function fgetattr(string $path, Stat $stat, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*lock) (const char *, struct fuse_file_info *, int cmd, struct flock *);
+     */
+    public function lock(string $path, FuseFileInfo $fuse_file_info, int $cmd, Flock $flock): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*utimens) (const char *, const struct timespec tv[2]);
+     *
+     * @param TypedCDataArray<TimeSpec> $tv
+     */
+    public function utimens(string $path, TypedCDataArray $tv): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*bmap) (const char *, size_t blocksize, uint64_t *idx);
+     */
+    public function bmap(string $path, int $blocksize, int &$idx): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*ioctl) (const char *, int cmd, void *arg, struct fuse_file_info *, unsigned int flags, void *data);
+     */
+    public function ioctl(
+        string $path,
+        int $cmd,
+        FuseIoctlArgPointer $arg,
+        FuseFileInfo $fuse_file_info,
+        int $flags,
+        FuseIoctlDataPointer $data
+    ): int {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*poll) (const char *, struct fuse_file_info *, struct fuse_pollhandle *ph, unsigned *reventsp);
+     */
+    public function poll(
+        string $path,
+        FuseFileInfo $fuse_file_info,
+        FusePollHandle $fuse_pollhandle,
+        int &$reventsp
+    ): int {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*write_buf) (const char *, struct fuse_bufvec *buf, off_t off, struct fuse_file_info *);
+     */
+    public function writeBuf(string $path, FuseBufVec $buf, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*read_buf) (const char *, struct fuse_bufvec **bufp, size_t size, off_t off, struct fuse_file_info *);
+     *
+     * @param TypedCDataArray<FuseBufVec> $bufp
+     */
+    public function readBuf(
+        string $path,
+        TypedCDataArray $bufp,
+        int $size,
+        int $offset,
+        FuseFileInfo $fuse_file_info
+    ): int {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*flock) (const char *, struct fuse_file_info *, int op);
+     */
+    public function flock(string $path, FuseFileInfo $fuse_file_info, int $op): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * int (*fallocate) (const char *, int, off_t, off_t, struct fuse_file_info *);
+     */
+    public function fallocate(string $path, int $mode, int $offset, FuseFileInfo $fuse_file_info): int
+    {
+        return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
+    }
+}

--- a/src/Filesystem/Overlay/OverlayFilesystem.php
+++ b/src/Filesystem/Overlay/OverlayFilesystem.php
@@ -311,7 +311,7 @@ final class OverlayFilesystem implements FilesystemInterface
     /**
      * void (*destroy) (void *);
      */
-    public function destroy(FusePrivateData $private_data): void
+    public function destroy(?FusePrivateData $private_data): void
     {
         $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }

--- a/src/Filesystem/Overlay/OverlayFilesystem.php
+++ b/src/Filesystem/Overlay/OverlayFilesystem.php
@@ -53,11 +53,14 @@ final class OverlayFilesystem implements FilesystemInterface
         $this->fallback = $fallback;
     }
 
+    /** @return int|FusePrivateData|null|void */
     private function fallbackIfDefault(string $method_name, array $args)
     {
         if (ReflectionFilesystem::instance($this->main)->isDefault($method_name)) {
+            /** @var int|FusePrivateData|null|void */
             return $this->fallback->$method_name(...$args);
         }
+        /** @var int|FusePrivateData|null|void */
         return $this->main->$method_name(...$args);
     }
 
@@ -66,6 +69,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function getattr(string $path, Stat $stat): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -74,6 +78,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function readlink(string $path, CStringBuffer $buffer, int $size): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -84,6 +89,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function getdir(string $path, FuseDirHandle $dirhandle, FuseDirFill $dirfill): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -92,6 +98,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function mknod(string $path, int $mode, int $dev): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -100,6 +107,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function mkdir(string $path, int $mode): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -108,6 +116,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function unlink(string $path): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -116,6 +125,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function rmdir(string $path): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -124,6 +134,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function symlink(string $path, string $link): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -132,6 +143,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function rename(string $from, string $to): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -140,6 +152,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function link(string $path, string $link): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -148,6 +161,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function chmod(string $path, int $mode): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -156,6 +170,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function chown(string $path, int $uid, int $gid): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -164,6 +179,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function truncate(string $path, int $offset): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -172,6 +188,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function utime(string $path, UtimBuf $utime_buf): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -180,6 +197,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function open(string $path, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -188,6 +206,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function read(string $path, CBytesBuffer $buffer, int $size, int $offset, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -196,6 +215,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function write(string $path, string $buffer, int $size, int $offset, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -204,6 +224,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function statfs(string $path, StatVfs $statvfs): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -212,6 +233,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function flush(string $path, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -220,6 +242,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function release(string $path, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -228,6 +251,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function fsync(string $path, int $flags, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -236,6 +260,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function setxattr(string $path, string $name, string $value, int $size): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -244,6 +269,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function getxattr(string $path, string $name, ?string &$value, int $size): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -252,6 +278,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function listxattr(string $path, ?string &$value, int $size): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -260,6 +287,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function removexattr(string $size, string $name): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -268,6 +296,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function opendir(string $path, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -281,6 +310,7 @@ final class OverlayFilesystem implements FilesystemInterface
         int $offset,
         FuseFileInfo $fuse_file_info
     ): int {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -289,6 +319,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function releasedir(string $path, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -297,6 +328,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function fsyncdir(string $path, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -305,6 +337,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function init(FuseConnInfo $conn): ?FusePrivateData
     {
+        /** @var null|FusePrivateData */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -321,6 +354,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function access(string $path, int $mode): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -329,6 +363,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function create(string $path, int $mode, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -337,6 +372,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function ftruncate(string $path, int $offset, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -345,6 +381,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function fgetattr(string $path, Stat $stat, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -353,6 +390,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function lock(string $path, FuseFileInfo $fuse_file_info, int $cmd, Flock $flock): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -363,6 +401,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function utimens(string $path, TypedCDataArray $tv): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -371,6 +410,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function bmap(string $path, int $blocksize, int &$idx): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -385,6 +425,7 @@ final class OverlayFilesystem implements FilesystemInterface
         int $flags,
         FuseIoctlDataPointer $data
     ): int {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -397,6 +438,7 @@ final class OverlayFilesystem implements FilesystemInterface
         FusePollHandle $fuse_pollhandle,
         int &$reventsp
     ): int {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -405,6 +447,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function writeBuf(string $path, FuseBufVec $buf, int $offset, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -420,6 +463,7 @@ final class OverlayFilesystem implements FilesystemInterface
         int $offset,
         FuseFileInfo $fuse_file_info
     ): int {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -428,6 +472,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function flock(string $path, FuseFileInfo $fuse_file_info, int $op): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 
@@ -436,6 +481,7 @@ final class OverlayFilesystem implements FilesystemInterface
      */
     public function fallocate(string $path, int $mode, int $offset, FuseFileInfo $fuse_file_info): int
     {
+        /** @var int */
         return $this->fallbackIfDefault(__FUNCTION__, func_get_args());
     }
 }

--- a/src/Filesystem/ReflectionFilesystem.php
+++ b/src/Filesystem/ReflectionFilesystem.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-fuse package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fuse\Filesystem;
+
+use Fuse\FilesystemDefaultImplementationTrait;
+use Fuse\FilesystemInterface;
+use ReflectionClass;
+
+final class ReflectionFilesystem
+{
+    private FilesystemInterface $filesystem;
+
+    public function __construct(FilesystemInterface $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    public static function instance(FilesystemInterface $filesystem)
+    {
+        return new self($filesystem);
+    }
+
+    public function isDefault(string $method_name): bool
+    {
+        $class = new ReflectionClass($this->filesystem);
+        $method = $class->getMethod($method_name);
+        $trait = new ReflectionClass(FilesystemDefaultImplementationTrait::class);
+        return $method->getFileName() === $trait->getFileName();
+    }
+}

--- a/src/Filesystem/ReflectionFilesystem.php
+++ b/src/Filesystem/ReflectionFilesystem.php
@@ -26,7 +26,7 @@ final class ReflectionFilesystem
         $this->filesystem = $filesystem;
     }
 
-    public static function instance(FilesystemInterface $filesystem)
+    public static function instance(FilesystemInterface $filesystem): self
     {
         return new self($filesystem);
     }

--- a/src/FilesystemDefaultImplementationTrait.php
+++ b/src/FilesystemDefaultImplementationTrait.php
@@ -37,6 +37,7 @@ use TypedCData\TypedCDataArray;
 trait FilesystemDefaultImplementationTrait
 {
     use MountableFilesystemTrait;
+    use FilesystemFlagsImplementationTrait;
 
     /**
      * int (*getattr) (const char *, struct stat *);
@@ -348,47 +349,6 @@ trait FilesystemDefaultImplementationTrait
     public function bmap(string $path, int $blocksize, int &$idx): int
     {
         return -Errno::ENOSYS;
-    }
-
-
-    /**
-     * unsigned int flag_nullpath_ok:1;
-     * unsigned int flag_nopath:1;
-     * unsigned int flag_utime_omit_ok:1;
-     * unsigned int flag_reserved:29;
-     */
-    private bool $flag_nullpath_ok = false;
-    private bool $flag_nopath = false;
-    private bool $flag_utime_omit_ok = false;
-
-    public function setFlagNullpathOk(bool $flag): void
-    {
-        $this->flag_nullpath_ok = $flag;
-    }
-
-    public function getFlagNullpathOk(): bool
-    {
-        return $this->flag_nullpath_ok;
-    }
-
-    public function setFlagNopath(bool $flag): void
-    {
-        $this->flag_nopath = $flag;
-    }
-
-    public function getFlagNopath(): bool
-    {
-        return $this->flag_nopath;
-    }
-
-    public function setFlagUtimeOmitOk(bool $flag): void
-    {
-        $this->flag_utime_omit_ok = $flag;
-    }
-
-    public function getFlagUtimeOmitOk(): bool
-    {
-        return $this->flag_utime_omit_ok;
     }
 
     /**

--- a/src/FilesystemDefaultImplementationTrait.php
+++ b/src/FilesystemDefaultImplementationTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Fuse;
 
+use Fuse\Libc\Errno\Errno;
 use Fuse\Libc\Fcntl\Flock;
 use Fuse\Libc\Fuse\FuseBufVec;
 use Fuse\Libc\Fuse\FuseConnInfo;
@@ -42,7 +43,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function getattr(string $path, Stat $stat): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -50,7 +51,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function readlink(string $path, CStringBuffer $buffer, int $size): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -60,7 +61,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function getdir(string $path, FuseDirHandle $dirhandle, FuseDirFill $dirfill): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -68,7 +69,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function mknod(string $path, int $mode, int $dev): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -76,7 +77,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function mkdir(string $path, int $mode): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -84,7 +85,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function unlink(string $path): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -92,7 +93,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function rmdir(string $path): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -100,7 +101,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function symlink(string $path, string $link): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -108,7 +109,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function rename(string $from, string $to): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -116,7 +117,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function link(string $path, string $link): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -124,7 +125,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function chmod(string $path, int $mode): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -132,7 +133,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function chown(string $path, int $uid, int $gid): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -140,7 +141,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function truncate(string $path, int $offset): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -148,7 +149,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function utime(string $path, UtimBuf $utime_buf): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -156,7 +157,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function open(string $path, FuseFileInfo $fuse_file_info): int
     {
-        throw new FuseLogicException('not implemented');
+        return 0;
     }
 
     /**
@@ -164,7 +165,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function read(string $path, CBytesBuffer $buffer, int $size, int $offset, FuseFileInfo $fuse_file_info): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -172,7 +173,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function write(string $path, string $buffer, int $size, int $offset, FuseFileInfo $fuse_file_info): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -180,7 +181,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function statfs(string $path, StatVfs $statvfs): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -188,7 +189,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function flush(string $path, FuseFileInfo $fuse_file_info): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -196,7 +197,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function release(string $path, FuseFileInfo $fuse_file_info): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -204,7 +205,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function fsync(string $path, int $flags, FuseFileInfo $fuse_file_info): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -212,23 +213,23 @@ trait FilesystemDefaultImplementationTrait
      */
     public function setxattr(string $path, string $name, string $value, int $size): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
      * int (*getxattr) (const char *, const char *, char *, size_t);
      */
-    public function getxattr(string $path, string $name, string &$value, int $size): int
+    public function getxattr(string $path, string $name, ?string &$value, int $size): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
      * int (*listxattr) (const char *, char *, size_t);*
      */
-    public function listxattr(string $path, int $size): int
+    public function listxattr(string $path, ?string &$value, int $size): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -236,7 +237,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function removexattr(string $size, string $name): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -244,7 +245,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function opendir(string $path, FuseFileInfo $fuse_file_info): int
     {
-        throw new FuseLogicException('not implemented');
+        return 0;
     }
 
     /**
@@ -257,7 +258,7 @@ trait FilesystemDefaultImplementationTrait
         int $offset,
         FuseFileInfo $fuse_file_info
     ): int {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -265,7 +266,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function releasedir(string $path, FuseFileInfo $fuse_file_info): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -273,7 +274,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function fsyncdir(string $path, FuseFileInfo $fuse_file_info): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -281,15 +282,14 @@ trait FilesystemDefaultImplementationTrait
      */
     public function init(FuseConnInfo $conn): ?FusePrivateData
     {
-        throw new FuseLogicException('not implemented');
+        return null;
     }
 
     /**
      * void (*destroy) (void *);
      */
-    public function destroy(FusePrivateData $private_data): void
+    public function destroy(?FusePrivateData $private_data): void
     {
-        throw new FuseLogicException('not implemented');
     }
 
     /**
@@ -297,7 +297,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function access(string $path, int $mode): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -305,7 +305,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function create(string $path, int $mode, FuseFileInfo $fuse_file_info): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -313,7 +313,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function ftruncate(string $path, int $offset, FuseFileInfo $fuse_file_info): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -321,7 +321,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function fgetattr(string $path, Stat $stat, FuseFileInfo $fuse_file_info): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -329,7 +329,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function lock(string $path, FuseFileInfo $fuse_file_info, int $cmd, Flock $flock): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -339,7 +339,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function utimens(string $path, TypedCDataArray $tv): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -347,7 +347,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function bmap(string $path, int $blocksize, int &$idx): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
 
@@ -402,7 +402,7 @@ trait FilesystemDefaultImplementationTrait
         int $flags,
         FuseIoctlDataPointer $data
     ): int {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -414,7 +414,7 @@ trait FilesystemDefaultImplementationTrait
         FusePollHandle $fuse_pollhandle,
         int &$reventsp
     ): int {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -422,15 +422,22 @@ trait FilesystemDefaultImplementationTrait
      */
     public function writeBuf(string $path, FuseBufVec $buf, int $offset, FuseFileInfo $fuse_file_info): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
      * int (*read_buf) (const char *, struct fuse_bufvec **bufp, size_t size, off_t off, struct fuse_file_info *);
+     *
+     * @param TypedCDataArray<FuseBufVec> $bufp
      */
-    public function readBuf(string $path, FuseBufVec $bufp, int $size, int $offset, FuseFileInfo $fuse_file_info): int
-    {
-        throw new FuseLogicException('not implemented');
+    public function readBuf(
+        string $path,
+        TypedCDataArray $bufp,
+        int $size,
+        int $offset,
+        FuseFileInfo $fuse_file_info
+    ): int {
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -438,7 +445,7 @@ trait FilesystemDefaultImplementationTrait
      */
     public function flock(string $path, FuseFileInfo $fuse_file_info, int $op): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 
     /**
@@ -446,6 +453,6 @@ trait FilesystemDefaultImplementationTrait
      */
     public function fallocate(string $path, int $mode, int $offset, FuseFileInfo $fuse_file_info): int
     {
-        throw new FuseLogicException('not implemented');
+        return -Errno::ENOSYS;
     }
 }

--- a/src/FilesystemFlagsImplementationTrait.php
+++ b/src/FilesystemFlagsImplementationTrait.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-fuse package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fuse;
+
+trait FilesystemFlagsImplementationTrait
+{
+    /**
+     * unsigned int flag_nullpath_ok:1;
+     * unsigned int flag_nopath:1;
+     * unsigned int flag_utime_omit_ok:1;
+     * unsigned int flag_reserved:29;
+     */
+    private bool $flag_nullpath_ok = false;
+    private bool $flag_nopath = false;
+    private bool $flag_utime_omit_ok = false;
+
+    public function setFlagNullpathOk(bool $flag): void
+    {
+        $this->flag_nullpath_ok = $flag;
+    }
+
+    public function getFlagNullpathOk(): bool
+    {
+        return $this->flag_nullpath_ok;
+    }
+
+    public function setFlagNopath(bool $flag): void
+    {
+        $this->flag_nopath = $flag;
+    }
+
+    public function getFlagNopath(): bool
+    {
+        return $this->flag_nopath;
+    }
+
+    public function setFlagUtimeOmitOk(bool $flag): void
+    {
+        $this->flag_utime_omit_ok = $flag;
+    }
+
+    public function getFlagUtimeOmitOk(): bool
+    {
+        return $this->flag_utime_omit_ok;
+    }
+}

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -196,7 +196,7 @@ interface FilesystemInterface extends Mountable
     /**
      * void (*destroy) (void *);
      */
-    public function destroy(FusePrivateData $private_data): void;
+    public function destroy(?FusePrivateData $private_data): void;
 
     /**
      * int (*access) (const char *, int);

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -150,12 +150,12 @@ interface FilesystemInterface extends Mountable
     /**
      * int (*getxattr) (const char *, const char *, char *, size_t);
      */
-    public function getxattr(string $path, string $name, string &$value, int $size): int;
+    public function getxattr(string $path, string $name, ?string &$value, int $size): int;
 
     /**
      * int (*listxattr) (const char *, char *, size_t);*
      */
-    public function listxattr(string $path, int $size): int;
+    public function listxattr(string $path, ?string &$value, int $size): int;
 
     /**
      * int (*removexattr) (const char *, const char *);
@@ -277,8 +277,16 @@ interface FilesystemInterface extends Mountable
 
     /**
      * int (*read_buf) (const char *, struct fuse_bufvec **bufp, size_t size, off_t off, struct fuse_file_info *);
+     *
+     * @param TypedCDataArray<FuseBufVec> $bufp
      */
-    public function readBuf(string $path, FuseBufVec $bufp, int $size, int $offset, FuseFileInfo $fuse_file_info): int;
+    public function readBuf(
+        string $path,
+        TypedCDataArray $bufp,
+        int $size,
+        int $offset,
+        FuseFileInfo $fuse_file_info
+    ): int;
 
     /**
      * int (*flock) (const char *, struct fuse_file_info *, int op);

--- a/src/FuseLogicException.php
+++ b/src/FuseLogicException.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Fuse;
 
+/** @deprecated */
 class FuseLogicException extends \LogicException
 {
 

--- a/src/FuseOperations.php
+++ b/src/FuseOperations.php
@@ -31,6 +31,7 @@ use Fuse\Libc\String\CBytesBuffer;
 use Fuse\Libc\String\CStringBuffer;
 use Fuse\Libc\Sys\Stat\Stat;
 use Fuse\Libc\Sys\StatVfs\StatVfs;
+use Fuse\Libc\Time\TimeSpec;
 use Fuse\Libc\Utime\UtimBuf;
 use ReflectionClass;
 use TypedCData\TypedCDataArray;
@@ -38,6 +39,8 @@ use TypedCData\TypedCDataWrapper;
 
 // phpcs:disable Generic.Files.LineLength
 /**
+ * @psalm-type TimeSpecArray       = TypedCDataArray<TimeSpec>
+ * @psalm-type FuseBufVecArray     = TypedCDataArray<FuseBufVec>
  * @psalm-type getattr_op          = callable(string $path, CData $stat): int
  * @psalm-type getattr_typed_op    = callable(string $path, Stat $stat): int
  * @psalm-type readlink_op         = callable(string $path, CData $buffer, int $size): int
@@ -71,7 +74,7 @@ use TypedCData\TypedCDataWrapper;
  * @psalm-type init_op             = callable(CData $conn): ?CData
  * @psalm-type init_typed_op       = callable(FuseConnInfo $conn): ?FusePrivateData
  * @psalm-type destroy_op          = callable(CData $private_data): void
- * @psalm-type destroy_typed_op    = callable(FusePrivateData $private_data): void
+ * @psalm-type destroy_typed_op    = callable(?FusePrivateData$private_data): void
  * @psalm-type create_op           = callable(string $path, int $mode, CData $fuse_file_info): int
  * @psalm-type create_typed_op     = callable(string $path, int $mode, FuseFileInfo $fuse_file_info): int
  * @psalm-type ftruncate_op        = callable(string $path, int $offset, CData $fuse_file_info): int
@@ -81,7 +84,7 @@ use TypedCData\TypedCDataWrapper;
  * @psalm-type lock_op             = callable(string $path, CData $fuse_file_info, int $cmd, CData $flock): int
  * @psalm-type lock_typed_op       = callable(string $path, FuseFileInfo $fuse_file_info, int $cmd, Flock $flock): int
  * @psalm-type utimens_op          = callable(string $path, CData $tv): int
- * @psalm-type utimens_typed_op    = callable(string $path, TypedCDataArray $tv): int
+ * @psalm-type utimens_typed_op    = callable(string $path, TimeSpecArray$tv): int
  * @psalm-type bmap_op             = callable(string $path, int $blocksize, CData $idx): int
  * @psalm-type bmap_typed_op       = callable(string $path, int $blocksize, int $idx): int
  * @psalm-type ioctl_op            = callable(string $path, int $cmd, CData $arg, CData $fuse_file_info, int $flags, CData $data): int
@@ -91,7 +94,7 @@ use TypedCData\TypedCDataWrapper;
  * @psalm-type write_buf_op        = callable(string $path, CData $buf, int $offset, CData $fuse_file_info): int
  * @psalm-type write_buf_typed_op  = callable(string $path, FuseBufVec $buf, int $offset, FuseFileInfo $fuse_file_info): int
  * @psalm-type read_buf_op         = callable(string $path, CData $bufp, int $size, int $offset, CData $fuse_file_info): int
- * @psalm-type read_buf_typed_op   = callable(string $path, FuseBufVec $bufp, int $size, int $offset, FuseFileInfo $fuse_file_info): int
+ * @psalm-type read_buf_typed_op   = callable(string $path, FuseBufVecArray $bufp, int $size, int $offset, FuseFileInfo $fuse_file_info): int
  * @psalm-type flock_op            = callable(string $path, CData $fuse_file_info, int $op): int
  * @psalm-type flock_typed_op      = callable(string $path, FuseFileInfo $fuse_file_info, int $op): int
  * @psalm-type fallocate_op        = callable(string $path, int $mode, int $offset, CData $fuse_file_info): int
@@ -265,7 +268,7 @@ final class FuseOperations implements Mountable
     /**
      * int (*listxattr) (const char *, char *, size_t);
      *
-     * @var null|callable(string $path, int $size): int
+     * @var null|callable(string $path, string $value, int $size): int
      */
     public $listxattr = null;
 

--- a/src/FuseOperations.php
+++ b/src/FuseOperations.php
@@ -444,6 +444,7 @@ final class FuseOperations implements Mountable
             }
             $fuse_operations->$name = $typed_cdata_wrapper->createWrapper($callable);
         }
+        assert(!is_null($fuse_operations));
         return $this->cdata_cache = $fuse_operations;
     }
 
@@ -467,6 +468,7 @@ final class FuseOperations implements Mountable
         $type = Fuse::getInstance()->ffi->type(
             $typename
         );
+        assert(!is_null($type));
         $size = FFI::sizeof(
             $type
         );

--- a/src/FuseOperations.php
+++ b/src/FuseOperations.php
@@ -439,27 +439,10 @@ final class FuseOperations implements Mountable
                 continue;
             }
             assert(is_callable($callable));
-            if ($this->isDefault($callable)) {
-                continue;
-            }
             $fuse_operations->$name = $typed_cdata_wrapper->createWrapper($callable);
         }
         assert(!is_null($fuse_operations));
         return $this->cdata_cache = $fuse_operations;
-    }
-
-    private function isDefault(callable $callable): bool
-    {
-        if (!is_array($callable)) {
-            return false;
-        }
-        if (!is_object($callable[0])) {
-            return false;
-        }
-        $class = new ReflectionClass(get_class($callable[0]));
-        $method = $class->getMethod($callable[1]);
-        $trait = new ReflectionClass(FilesystemDefaultImplementationTrait::class);
-        return $method->getFileName() === $trait->getFileName();
     }
 
     public function getSize(): int

--- a/src/Libc/Fuse/FuseDirFill.php
+++ b/src/Libc/Fuse/FuseDirFill.php
@@ -26,6 +26,7 @@ final class FuseDirFill implements TypedCDataInterface
 
     public function __invoke(FuseDirHandle $dirhandle, string $name, int $type, int $ino): int
     {
+        /** @var int */
         return ($this->cdata)($dirhandle->toCData(null), $name, $type, $ino);
     }
 

--- a/src/Libc/Fuse/FuseFillDir.php
+++ b/src/Libc/Fuse/FuseFillDir.php
@@ -30,6 +30,7 @@ final class FuseFillDir implements TypedCDataInterface
         if (!is_null($stbuf)) {
             $stbuf = $stbuf->toCData($stbuf->newCData());
         }
+        /** @var int */
         return ($this->cdata)($buf->toCData(null), $name, $stbuf, $off);
     }
 

--- a/src/Libc/String/CBytesBuffer.php
+++ b/src/Libc/String/CBytesBuffer.php
@@ -48,6 +48,7 @@ final class CBytesBuffer implements TypedCDataInterface
 
     public static function newCData(): CData
     {
+        /** @var CData */
         return \FFI::new('char[1]');
     }
 }

--- a/src/Libc/String/CStringBuffer.php
+++ b/src/Libc/String/CStringBuffer.php
@@ -43,6 +43,7 @@ final class CStringBuffer implements TypedCDataInterface
 
     public static function newCData(): CData
     {
+        /** @var CData */
         return \FFI::new('char[1]');
     }
 }

--- a/src/MountableFilesystemTrait.php
+++ b/src/MountableFilesystemTrait.php
@@ -218,12 +218,12 @@ trait MountableFilesystemTrait
     /**
      * int (*getxattr) (const char *, const char *, char *, size_t);
      */
-    abstract public function getxattr(string $path, string $name, string &$value, int $size): int;
+    abstract public function getxattr(string $path, string $name, ?string &$value, int $size): int;
 
     /**
      * int (*listxattr) (const char *, char *, size_t);*
      */
-    abstract public function listxattr(string $path, int $size): int;
+    abstract public function listxattr(string $path, ?string &$value, int $size): int;
 
     /**
      * int (*removexattr) (const char *, const char *);
@@ -345,10 +345,12 @@ trait MountableFilesystemTrait
 
     /**
      * int (*read_buf) (const char *, struct fuse_bufvec **bufp, size_t size, off_t off, struct fuse_file_info *);
+     *
+     * @param TypedCDataArray<FuseBufVec> $bufp
      */
     abstract public function readBuf(
         string $path,
-        FuseBufVec $bufp,
+        TypedCDataArray $bufp,
         int $size,
         int $offset,
         FuseFileInfo $fuse_file_info

--- a/src/MountableFilesystemTrait.php
+++ b/src/MountableFilesystemTrait.php
@@ -264,7 +264,7 @@ trait MountableFilesystemTrait
     /**
      * void (*destroy) (void *);
      */
-    abstract public function destroy(FusePrivateData $private_data): void;
+    abstract public function destroy(?FusePrivateData $private_data): void;
 
     /**
      * int (*access) (const char *, int);


### PR DESCRIPTION
# Changes
- Deprecate FuseLogicException
- Separate out flags implementation from FilesystemDefaultImplementationTrait
- Fix the wrong signatures of some FUSE APIs (getxattr, listxattr, destroy, and readBuf), which caused TypeError when actually used
- Fix examples
- Update dependencies

# Added
## Built-in Filesystems
### NullFilesystem
- A filesystem that does nothing

### BeforeAllFilesystem
- A wrapper filesystem that calls a given callback before processing each FUSE APIs

### OverlayFilesystem
- A filesystem that wraps two filesystems, namely main and fallback
- If the main filesystem doesn't have implementations for specific FUSE APIs, implementations of the fallback filesystem is used

### DelegationFilesystemTrait
- A trait for creating a filesystem that delegates call to FUSE APIs, which don't have their own implementation, to another filesystem.

### LogUnimplementedFilesystem
- A wrapper filesystem that logs call to unimplemented FUSE APIs
- It takes PSR-3 LoggerInterface to log the calls
